### PR TITLE
Support environments without `process.argv`

### DIFF
--- a/lib/system/has-flag.js
+++ b/lib/system/has-flag.js
@@ -25,7 +25,7 @@ SOFTWARE.
 'use strict';
 
 module.exports = function(flag, argv) {
-  argv = argv || process.argv;
+  argv = argv || process.argv || [];
 
   var terminatorPos = argv.indexOf('--');
   var prefix = /^-{1,2}/.test(flag) ? '' : '--';


### PR DESCRIPTION
Defaults to an empty array when `process.argv` is `undefined` (like on Edge Runtime). Fixes #41.